### PR TITLE
Fix createAccounts.sh for Onyx testnet

### DIFF
--- a/createAccounts.sh
+++ b/createAccounts.sh
@@ -4,7 +4,7 @@
 BEACON_CONTRACT="0x0F0F0fc0530007361933EaB5DB97d09aCDD6C1c8" # Onyx testnet
 
 VALIDATORS=98    # Number of validators to create
-GAS_LIMIT=400000 # Max gas for funding transactio
+GAS_LIMIT=400000 # Max gas for funding transactions
 
 
 for ((i=1; i<=$VALIDATORS; i++)) do

--- a/createAccounts.sh
+++ b/createAccounts.sh
@@ -7,16 +7,14 @@ VALIDATORS=98    # Number of validators to create
 GAS_LIMIT=400000 # Max gas for funding transactio
 
 
-LASTVALIDATOR=$(($VALIDATORS-1))
-
-for i in $(seq 0 $LASTVALIDATOR); do
+for ((i=1; i<=$VALIDATORS; i++)) do
 	docker-compose -f create-account.yaml run validator-create-account > /tmp/validatorcreateoutput
 	RAWTXDATA=$(sed -n 8,1p /tmp/validatorcreateoutput | tr -d '\r')
 	# echo $RAWTXDATA
 	SEND_CMD="web3.eth.sendTransaction({ from: web3.eth.coinbase, to: '$BEACON_CONTRACT', value: web3.toWei(32, 'ether'), data: '${RAWTXDATA}', gas: $GAS_LIMIT })"
 	# echo "$SEND_CMD"
 	eval "docker exec -it geth geth attach http://localhost:8545/ --exec=\"$SEND_CMD\""
-	echo "sent successful, $seq"
+	echo "sent successful, $i"
 done
 
 rm /tmp/validatorcreateoutput

--- a/createAccounts.sh
+++ b/createAccounts.sh
@@ -3,8 +3,8 @@
 # BEACON_CONTRACT="0x5ca1e00004366ac85f492887aaab12d0e6418876" # Topaz testnet
 BEACON_CONTRACT="0x0F0F0fc0530007361933EaB5DB97d09aCDD6C1c8" # Onyx testnet
 
-VALIDATORS=98
-
+VALIDATORS=98    # Number of validators to create
+GAS_LIMIT=400000 # Max gas for funding transactio
 
 
 LASTVALIDATOR=$(($VALIDATORS-1))
@@ -13,7 +13,7 @@ for i in $(seq 0 $LASTVALIDATOR); do
 	docker-compose -f create-account.yaml run validator-create-account > /tmp/validatorcreateoutput
 	RAWTXDATA=$(sed -n 8,1p /tmp/validatorcreateoutput | tr -d '\r')
 	# echo $RAWTXDATA
-	SEND_CMD="web3.eth.sendTransaction({ from: web3.eth.coinbase, to: '$BEACON_CONTRACT', value: web3.toWei(32, 'ether'), data: '${RAWTXDATA}' })"
+	SEND_CMD="web3.eth.sendTransaction({ from: web3.eth.coinbase, to: '$BEACON_CONTRACT', value: web3.toWei(32, 'ether'), data: '${RAWTXDATA}', gas: $GAS_LIMIT })"
 	# echo "$SEND_CMD"
 	eval "docker exec -it geth geth attach http://localhost:8545/ --exec=\"$SEND_CMD\""
 	echo "sent successful, $seq"

--- a/createAccounts.sh
+++ b/createAccounts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-BEACON_CONTRACT="0x5ca1e00004366ac85f492887aaab12d0e6418876"
+# BEACON_CONTRACT="0x5ca1e00004366ac85f492887aaab12d0e6418876" # Topaz testnet
+BEACON_CONTRACT="0x0F0F0fc0530007361933EaB5DB97d09aCDD6C1c8" # Onyx testnet
 
 VALIDATORS=98
 
@@ -10,7 +11,7 @@ LASTVALIDATOR=$(($VALIDATORS-1))
 
 for i in $(seq 0 $LASTVALIDATOR); do
 	docker-compose -f create-account.yaml run validator-create-account > /tmp/validatorcreateoutput
-	RAWTXDATA=$(sed -n 9,1p /tmp/validatorcreateoutput | tr -d '\r')
+	RAWTXDATA=$(sed -n 8,1p /tmp/validatorcreateoutput | tr -d '\r')
 	# echo $RAWTXDATA
 	SEND_CMD="web3.eth.sendTransaction({ from: web3.eth.coinbase, to: '$BEACON_CONTRACT', value: web3.toWei(32, 'ether'), data: '${RAWTXDATA}' })"
 	# echo "$SEND_CMD"


### PR DESCRIPTION
## Description

Fixes a few things that were broken in the `createAccounts.sh` script:

1. Wrong deposit contract address for Onyx testnet
2. Missing depositdata
3. Transactions running out of gas. 

This fixes #15.