### PR TITLE
changed validators datadir flag

### DIFF
--- a/config/validator.yaml
+++ b/config/validator.yaml
@@ -11,7 +11,8 @@ beacon-rpc-provider: beacon:4000
 monitoring-host: 0.0.0.0
 
 #####################################
-# Validator accounts & key management
+# Validator database, accounts & key management
+datadir: /data/db
 wallet-dir: /data/wallets
 wallet-password-file: /data/passwords/wallet-password
 


### PR DESCRIPTION
defined datadir flag so that an exiting database can be used when a new validator container is started